### PR TITLE
Moved internal led code from chainable LED to ledpack

### DIFF
--- a/docs/components/chainable-rgb-led/chainable-rgb-led.md
+++ b/docs/components/chainable-rgb-led/chainable-rgb-led.md
@@ -14,32 +14,6 @@ More detailed component information can be found [here](https://www.seeedstudio.
 
 ---
 
-## Blinking the internal LED (D13)
-```python
-# --- Imports
-import digitalio
-import time
-import board
-
-# --- Variables
-led = digitalio.DigitalInOut(board.D13)
-led.direction = digitalio.Direction.OUTPUT
-
-# --- Functions
-
-# --- Setup
-led.value = False
-
-# --- Main loop
-while True:
-    print("hello world")
-    led.value = True
-    time.sleep(0.5)
-    led.value = False
-    time.sleep(0.1)
-
-```
-
 ## Blinking a Chainable LED connected to D13 (and D10)
 The ItsyBitsy doesn't have a built-in library to control the chainable LEDs. We will need to download one! Grove Chainable LEDs are controlled by `P9813` LED drivers, hence the need for a library that knows how to interact with these drivers. 
 1. Download the [`P9813` library](assets/p9813.py). 

--- a/docs/components/led-pack/led-pack.md
+++ b/docs/components/led-pack/led-pack.md
@@ -14,6 +14,33 @@ More detailed component information can be found [here](https://www.seeedstudio.
 
 ---
 
+## Blinking the internal LED (D13)
+**This is only for the interal LED, a chainable LED does NOT work with this code (also not in port D13).
+```python
+# --- Imports
+import digitalio
+import time
+import board
+
+# --- Variables
+led = digitalio.DigitalInOut(board.D13)
+led.direction = digitalio.Direction.OUTPUT
+
+# --- Functions
+
+# --- Setup
+led.value = False
+
+# --- Main loop
+while True:
+    print("hello world")
+    led.value = True
+    time.sleep(0.5)
+    led.value = False
+    time.sleep(0.1)
+
+```
+
 ## Blinking the LED Pack (connected to D2)
 If the touch sensor is touched, turn the internal LED on. Otherwise turn the LED off.
 ```python

--- a/docs/components/led-pack/led-pack.md
+++ b/docs/components/led-pack/led-pack.md
@@ -15,7 +15,7 @@ More detailed component information can be found [here](https://www.seeedstudio.
 ---
 
 ## Blinking the internal LED (D13)
-**This is only for the interal LED, a chainable LED does NOT work with this code (also not in port D13).
+**This is for the interal LED, however a led-pack does work in port D13. a chainable LED does NOT work with this code.
 ```python
 # --- Imports
 import digitalio

--- a/docs/components/led-pack/led-pack.md
+++ b/docs/components/led-pack/led-pack.md
@@ -15,7 +15,8 @@ More detailed component information can be found [here](https://www.seeedstudio.
 ---
 
 ## Blinking the internal LED (D13)
-**This is for the interal LED, however a led-pack does work in port D13. a chainable LED does NOT work with this code.
+This is for the interal LED, however a LED Pack does work in port D13. A [Chainable RGB LED](../chainable-rgb-led/chainable-rgb-led) does *NOT* work with this code.
+
 ```python
 # --- Imports
 import digitalio


### PR DESCRIPTION
A lot of students tried to use the first piece of code for the chainable LED. This piece of code is however used for the internal LED and can be used with the led pack, not with the chainable LED. Therefore moving this piece of code to led-pack makes more sense.